### PR TITLE
added whitespace as possible thousands separator to regex in dscan parsing code

### DIFF
--- a/dscan/functions.php
+++ b/dscan/functions.php
@@ -34,7 +34,7 @@ function parseDscan($dscan) {
 	//Iterate through our rows
 	foreach($rows as $row) {
 		//Check if it matches a dscan row format
-		if(preg_match("/^([^\t]+)\t([^\t]+)\t(([0-9,.]+) (km|m|AU)|-)/", $row, $matches) == 1) {
+		if(preg_match("/^([^\t]+)\t([^\t]+)\t(([0-9,.\s]+) (km|m|AU)|-)/", $row, $matches) == 1) {
 			$ob['type'] = $matches[2];
 			$ob['name'] = $matches[1];
 			


### PR DESCRIPTION
A bro thought his dscan didn't work because of Korean characters.

Turned out to be space as thousands separator in whatever fucked up localisation of EVE he's using.

Fixed it to show some love for people with weird localisations.